### PR TITLE
Replace "MySQL8Dialect" with "MySQLDialect"

### DIFF
--- a/source-code/fullstack-library-app-https/02-backend/spring-boot-library/spring-boot-library/src/main/resources/application.properties
+++ b/source-code/fullstack-library-app-https/02-backend/spring-boot-library/spring-boot-library/src/main/resources/application.properties
@@ -3,7 +3,7 @@ spring.datasource.url=jdbc:mysql://localhost:3306/reactlibrarydatabase?useSSL=fa
 spring.datasource.username=root
 spring.datasource.password=test1234!
 
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 spring.data.rest.base-path=/api
 

--- a/source-code/fullstack-library-app/01-starter-files/application.properties
+++ b/source-code/fullstack-library-app/01-starter-files/application.properties
@@ -3,6 +3,6 @@ spring.datasource.url=jdbc:mysql://localhost:3306/demo?useSSL=false&useUnicode=y
 spring.datasource.username=root
 spring.datasource.password=test1234!
 
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 spring.data.rest.base-path=/api

--- a/source-code/fullstack-library-app/02-backend/spring-boot-library/spring-boot-library/src/main/resources/application.properties
+++ b/source-code/fullstack-library-app/02-backend/spring-boot-library/spring-boot-library/src/main/resources/application.properties
@@ -3,7 +3,7 @@ spring.datasource.url=jdbc:mysql://localhost:3306/reactlibrarydatabase?useSSL=fa
 spring.datasource.username=root
 spring.datasource.password=test1234!
 
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 spring.data.rest.base-path=/api
 


### PR DESCRIPTION
Based on the error messages:
`HHH90000026: MySQL8Dialect has been deprecated; use org.hibernate.dialect.MySQLDialect instead`

![error logs](https://github.com/darbyluv2code/fullstack-react-and-springboot/assets/111794971/216fd29c-4db6-46b6-8fa6-55bee2d2abf0)
